### PR TITLE
Remove unneeded argument.

### DIFF
--- a/src/AuthorizationService.php
+++ b/src/AuthorizationService.php
@@ -18,6 +18,7 @@ namespace Phauthentic\Authorization;
 use Phauthentic\Authorization\Policy\BeforePolicyInterface;
 use Phauthentic\Authorization\Policy\Exception\MissingMethodException;
 use Phauthentic\Authorization\Policy\ResolverInterface;
+use Phauthentic\Authorization\Policy\ResultInterface;
 use RuntimeException;
 
 /**
@@ -60,16 +61,23 @@ class AuthorizationService implements AuthorizationServiceInterface
         if ($policy instanceof BeforePolicyInterface) {
             $result = $policy->before($user, $resource, $action);
 
-            if (is_bool($result)) {
+            if ($result instanceof ResultInterface || is_bool($result)) {
                 return $result;
             }
             if ($result !== null) {
-                throw new RuntimeException('Pre-authorization check must return `bool` or `null`.');
+                throw new RuntimeException(
+                    'Pre-authorization check must return `Phauthentic\Authorization\Policy\ResultInterface`, '
+                    . '`bool` or `null`.'
+                );
             }
         }
 
         $handler = $this->getCanHandler($policy, $action);
         $result = $handler($user, $resource);
+
+        if ($result instanceof ResultInterface) {
+            return $result;
+        }
 
         return $result === true;
     }

--- a/src/AuthorizationServiceProviderInterface.php
+++ b/src/AuthorizationServiceProviderInterface.php
@@ -15,7 +15,6 @@ declare(strict_types = 1);
  */
 namespace Phauthentic\Authorization;
 
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -27,8 +26,7 @@ interface AuthorizationServiceProviderInterface
      * Returns authorization service instance.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request Request
-     * @param \Psr\Http\Message\ResponseInterface $response Response
      * @return \Phauthentic\Authorization\AuthorizationServiceInterface
      */
-    public function getAuthorizationService(ServerRequestInterface $request, ResponseInterface $response): AuthorizationServiceInterface;
+    public function getAuthorizationService(ServerRequestInterface $request): AuthorizationServiceInterface;
 }

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -16,6 +16,8 @@ declare(strict_types = 1);
 
 namespace Phauthentic\Authorization\Exception;
 
+use Phauthentic\Authorization\Policy\ResultInterface;
+
 /**
  * Forbidden Exception
  */
@@ -24,10 +26,39 @@ class ForbiddenException extends Exception
     /**
      * {@inheritDoc}
      */
-    protected $_defaultCode = 403;
+    protected $code = 403;
 
     /**
      * {@inheritDoc}
      */
     protected $messageTemplate = 'Identity is not authorized to perform `%s` on `%s`.';
+    /**
+     * Policy check result.
+     *
+     * @var \ Phauthentic\Authorization\Policy\ResultInterface|null
+     */
+    protected $result;
+
+    /**
+     * Returns policy check result if passed to the exception.
+     *
+     * @param \Phauthentic\Authorization\Policy\ResultInterface|null $result Result
+     * @return $this
+     */
+    public function setResult(?ResultInterface $result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * Returns policy check result if passed to the exception.
+     *
+     * @return \Phauthentic\Authorization\Policy\ResultInterface|null
+     */
+    public function getResult(): ?ResultInterface
+    {
+        return $this->result;
+    }
 }

--- a/src/IdentityDecorator.php
+++ b/src/IdentityDecorator.php
@@ -65,7 +65,7 @@ class IdentityDecorator implements IdentityInterface
     /**
      * {@inheritDoc}
      */
-    public function can($action, $resource): bool
+    public function can($action, $resource)
     {
         return $this->authorization->can($this, $action, $resource);
     }

--- a/src/IdentityInterface.php
+++ b/src/IdentityInterface.php
@@ -33,7 +33,7 @@ interface IdentityInterface extends ArrayAccess
      * @param mixed $resource The resource being operated on.
      * @return bool
      */
-    public function can($action, $resource): bool;
+    public function can($action, $resource);
 
     /**
      * Apply authorization scope conditions/restrictions.

--- a/src/Policy/BeforePolicyInterface.php
+++ b/src/Policy/BeforePolicyInterface.php
@@ -32,7 +32,7 @@ interface BeforePolicyInterface
      * @param \Phauthentic\Authorization\IdentityInterface|null $identity Identity object.
      * @param mixed $resource The resource being operated on.
      * @param string $action The action/operation being performed.
-     * @return bool|null
+     * @return \Phauthentic\Authorization\Policy\ResultInterface|bool|null
      */
-    public function before(?IdentityInterface $identity, $resource, string $action): ?bool;
+    public function before(?IdentityInterface $identity, $resource, string $action);
 }

--- a/src/Policy/RequestPolicyInterface.php
+++ b/src/Policy/RequestPolicyInterface.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Phauthentic\Authorization\Policy;
+
+use Phauthentic\Authorization\IdentityInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * This interface should be implemented by your request policy class.
+ */
+interface RequestPolicyInterface
+{
+    /**
+     * Method to check if the request can be accessed
+     *
+     * @param \Phauthentic\Authorization\IdentityInterface|null $identity Identity
+     * @param \Psr\Http\Message\ServerRequestInterface $request Server Request
+     * @return bool|\Phauthentic\Authorization\Policy\ResultInterface
+     */
+    public function canAccess(?IdentityInterface $identity, ServerRequestInterface $request);
+}

--- a/src/Policy/ResolverCollection.php
+++ b/src/Policy/ResolverCollection.php
@@ -40,7 +40,7 @@ use Phauthentic\Authorization\Policy\Exception\MissingPolicyException;
  * $service = new AuthenticationService($collection);
  * ```
  */
-class ResolverCollection implements ResolverCollectionInterface
+class ResolverCollection implements ResolverInterface, ResolverCollectionInterface
 {
     /**
      * Policy resolver instances.
@@ -90,5 +90,21 @@ class ResolverCollection implements ResolverCollectionInterface
     public function getIterator()
     {
         return new ArrayIterator($this->resolvers);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPolicy($resource)
+    {
+        foreach ($this->resolvers as $resolver) {
+            try {
+                return $resolver->getPolicy($resource);
+            } catch (MissingPolicyException $e) {
+            }
+        }
+
+        $exception = new MissingPolicyException();
+        throw $exception->setMessageVars([get_class($resource)]);
     }
 }

--- a/src/Policy/Result.php
+++ b/src/Policy/Result.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Phauthentic\Authorization\Policy;
+
+/**
+ * Policy check result
+ */
+class Result implements ResultInterface
+{
+    /**
+     * Check status.
+     *
+     * @var bool
+     */
+    protected $status;
+
+    /**
+     * Failure reason.
+     *
+     * @var string|null
+     */
+    protected $reason;
+
+    /**
+     * Constructor
+     *
+     * @param bool $status Check status.
+     * @param string|null $reason Failure reason.
+     */
+    public function __construct(bool $status, ?string $reason = null)
+    {
+        $this->status = (bool)$status;
+        if ($reason !== null) {
+            $this->reason = (string)$reason;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStatus(): bool
+    {
+        return $this->status;
+    }
+}

--- a/src/Policy/ResultInterface.php
+++ b/src/Policy/ResultInterface.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Phauthentic\Authorization\Policy;
+
+/**
+ * Policy check result interface
+ */
+interface ResultInterface
+{
+    /**
+     * Returns policy check status.
+     *
+     * @return bool
+     */
+    public function getStatus(): bool;
+
+    /**
+     * Optional reason why policy check has failed.
+     *
+     * @return string|null
+     */
+    public function getReason(): ?string;
+}

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -1,6 +1,7 @@
 <?php
 namespace TestApp\Policy;
 
+use Phauthentic\Authorization\Policy\Result;
 use TestApp\Model\Entity\Article;
 
 class ArticlePolicy
@@ -81,5 +82,23 @@ class ArticlePolicy
         }
 
         return true;
+    }
+
+    /**
+     * Testing that the article can be published
+     *
+     * This tests Result objects.
+     *
+     * @param \Authorization\IdentityInterface|null $user
+     * @param Article $article
+     * @return Result
+     */
+    public function canPublish($user, Article $article)
+    {
+        if ($article->get('visibility') === 'public') {
+            return new Result(false, 'public');
+        }
+
+        return new Result($article->get('user_id') === $user['id']);
     }
 }

--- a/tests/test_app/TestApp/Policy/ArticlesTablePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlesTablePolicy.php
@@ -6,6 +6,11 @@ use Cake\Datasource\QueryInterface;
 
 class ArticlesTablePolicy
 {
+    public function canIndex(IdentityInterface $identity)
+    {
+        return $identity['can_index'];
+    }
+
     public function canEdit(IdentityInterface $identity)
     {
         return $identity['can_edit'];

--- a/tests/test_app/TestApp/Policy/RequestPolicy.php
+++ b/tests/test_app/TestApp/Policy/RequestPolicy.php
@@ -2,11 +2,13 @@
 namespace TestApp\Policy;
 
 use Cake\Http\ServerRequest;
+use Phauthentic\Authorization\Policy\RequestPolicyInterface;
+use Phauthentic\Authorization\Policy\Result;
 
 /**
  * For testing request based policies
  */
-class RequestPolicy
+class RequestPolicy implements RequestPolicyInterface
 {
     /**
      * Method to check if the request can be accessed
@@ -24,5 +26,23 @@ class RequestPolicy
         }
 
         return false;
+    }
+
+    /**
+     * Method to check if the request can be accessed
+     *
+     * @param null|\Authorization\IdentityInterface Identity
+     * @param \Cake\Http\ServerRequest $request Request
+     * @return \Authorization\Policy\ResultInterface
+     */
+    public function canEnter($identity, ServerRequest $request)
+    {
+        if ($request->getParam('controller') === 'Articles'
+            && $request->getParam('action') === 'index'
+        ) {
+            return new Result(true);
+        }
+
+        return new Result(false, 'wrong action');
     }
 }


### PR DESCRIPTION
ServiceProvider instance are used through middleware which no longer get's Response instance as argument.