### PR TITLE
Allow policy methods to return boolean again.

### DIFF
--- a/src/Policy/BeforePolicyInterface.php
+++ b/src/Policy/BeforePolicyInterface.php
@@ -32,7 +32,7 @@ interface BeforePolicyInterface
      * @param \Phauthentic\Authorization\IdentityInterface|null $identity Identity object.
      * @param mixed $resource The resource being operated on.
      * @param string $action The action/operation being performed.
-     * @return \Phauthentic\Authorization\Policy\ResultInterface|null
+     * @return \Phauthentic\Authorization\Policy\ResultInterface|bool|null
      */
-    public function before(?IdentityInterface $identity, $resource, string $action): ?ResultInterface;
+    public function before(?IdentityInterface $identity, $resource, string $action);
 }

--- a/src/Policy/RequestPolicyInterface.php
+++ b/src/Policy/RequestPolicyInterface.php
@@ -28,7 +28,7 @@ interface RequestPolicyInterface
      *
      * @param \Phauthentic\Authorization\IdentityInterface|null $identity Identity
      * @param \Psr\Http\Message\ServerRequestInterface $request Server Request
-     * @return \Phauthentic\Authorization\Policy\ResultInterface
+     * @return \Phauthentic\Authorization\Policy\ResultInterface|bool
      */
-    public function canAccess(?IdentityInterface $identity, ServerRequestInterface $request): ResultInterface;
+    public function canAccess(?IdentityInterface $identity, ServerRequestInterface $request);
 }

--- a/tests/test_app/TestApp/Policy/ArticlePolicy.php
+++ b/tests/test_app/TestApp/Policy/ArticlePolicy.php
@@ -15,25 +15,25 @@ class ArticlePolicy
      */
     public function canAdd($user)
     {
-        return new Result(in_array($user['role'], ['admin', 'author']));
+        return in_array($user['role'], ['admin', 'author']);
     }
 
     public function canEdit($user, Article $article)
     {
         if (in_array($user['role'], ['admin', 'author'])) {
-            return new Result(true);
+            return true;
         }
 
-        return new Result($article->get('user_id') === $user['id']);
+        return $article->get('user_id') === $user['id'];
     }
 
     public function canModify($user, Article $article)
     {
         if (in_array($user['role'], ['admin', 'author'])) {
-            return new Result(true);
+            return true;
         }
 
-        return new Result($article->get('user_id') === $user['id']);
+        return $article->get('user_id') === $user['id'];
     }
 
     /**
@@ -46,10 +46,10 @@ class ArticlePolicy
     public function canDelete($user, Article $article)
     {
         if ($user['role'] === 'admin') {
-            return new Result(true);
+            return true;
         }
 
-        return new Result($user['id'] === $article->get('user_id'));
+        return $user['id'] === $article->get('user_id');
     }
 
     /**
@@ -78,10 +78,10 @@ class ArticlePolicy
     public function canView($user, Article $article)
     {
         if ($article->get('visibility') !== 'public' && empty($user)) {
-            return new Result(false);
+            return false;
         }
 
-        return new Result(true);
+        return true;
     }
 
     /**


### PR DESCRIPTION
This retains usability as in most cases users won't need to set custom error message/reason so returning boolean is lot more convenient.

`AuthorizationServiceInterface::can()` and `IndentityInterface::can()` will still always return `ResultInterface` instance.